### PR TITLE
Allow x-forwarded-for header to support lists with spaces around the commas

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function forwarded(headers, whitelist) {
     if (!(proxies[i].ip in headers)) continue;
 
     ports = (headers[proxies[i].port] || '').split(',');
-    ips = (headers[proxies[i].ip] || '').split(',');
+    ips = (headers[proxies[i].ip] || '').replace(/\s*,\s*/, ',').split(',');
     proto = (headers[proxies[i].proto] || 'http');
 
     //

--- a/index.js
+++ b/index.js
@@ -50,6 +50,13 @@ var proxies = [
 ];
 
 /**
+ * Regex to match any comma surrounded by optional whitespace
+ *
+ * @type {RegExp}
+ */
+var ipListSpaceFilter = /\s*,\s*/;
+
+/**
  * Search the headers for a possible match against a known proxy header.
  *
  * @param {Object} headers The received HTTP headers.
@@ -64,7 +71,7 @@ function forwarded(headers, whitelist) {
     if (!(proxies[i].ip in headers)) continue;
 
     ports = (headers[proxies[i].port] || '').split(',');
-    ips = (headers[proxies[i].ip] || '').replace(/\s*,\s*/, ',').split(',');
+    ips = (headers[proxies[i].ip] || '').replace(ipListSpaceFilter, ',').split(',');
     proto = (headers[proxies[i].proto] || 'http');
 
     //


### PR DESCRIPTION
Our network structure that alters `X-Forwarded-For`:
External Interface/Firewall -> HAProxy -> Nginx/Node

HAProxy appends to the list of ips with a `, ` (comma + space).

This PR will allow the spaces to be parsed out of the list before it's split.

https://tools.ietf.org/html/draft-ietf-appsawg-http-forwarded-10#section-7.1